### PR TITLE
fixing the /usr/bin/ld: cannot find -lGLESv2 error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,8 @@
       ],
       "ldflags": [
         "-L/opt/vc/lib",
-        "-lGLESv2"
+        "-lbrcmEGL",
+        "-lbrcmGLESv2"
       ],
       "cflags": [
         "-DENABLE_GDB_JIT_INTERFACE",


### PR DESCRIPTION
After an error while trying to compile npm install node-opengv-canvas & digging an answer from https://raspberrypi.stackexchange.com/questions/77619/where-is-legl-lglesv2, I guess this may solve the troubles ;p

Also, do you support dispmanX ? (.it 'd be really cool to have a transparent background canvas to be able to see stuff on layers below it ;p )

Thanks for opening & openvg-canva btw :)

Keep up the good work ++

Some of the error logs:
CXX(target) Release/obj.target/init-egl/src/init-egl.o
  SOLINK_MODULE(target) Release/obj.target/init-egl.node
/usr/bin/ld: cannot find -lGLESv2
collect2: error: ld returned 1 exit status